### PR TITLE
Handle case where Origin is set to 'null' in request

### DIFF
--- a/lib/cors/cors.ml
+++ b/lib/cors/cors.ml
@@ -298,7 +298,7 @@ let handle_cors is_preflight conf inner_handler req =
     Dream.add_header rep "Access-Control-Expose-Headers"
     @@ hdr_str_of_list conf.expose_headers;
     if conf.set_vary_header then build_vary_header rep;
-    print_all_headers rep; (* Debug *)
+    Utils.print_all_headers rep; (* Debug *)
     Lwt.return rep)
 
 let make_cors : cors_conf -> Dream.middleware = 

--- a/lib/cors/cors.ml
+++ b/lib/cors/cors.ml
@@ -6,6 +6,7 @@ type cors_conf = {
   max_age : float;
   preflight : bool;
   set_vary_header : bool;
+  allow_no_origin : bool;
 }
 
 and allowed_origin_type =
@@ -105,7 +106,7 @@ let is_valid_max_age ma = if ma < 0. || ma > 86400. then false else true
 
 let make_cors_conf ~allowed_origin ~allowed_methods ~allowed_headers
     ~expose_headers ?(max_age = 7200.) ?(preflight = true)
-    ?(set_vary_header = true) () =
+    ?(set_vary_header = true) ?(allow_no_origin = false) () =
   if not @@ is_valid_max_age max_age then
     raise (InvalidMaxAge "max_age: Max age must be between 0 and 86400 seconds")
   else if not @@ is_valid_origin_ty allowed_origin then
@@ -125,6 +126,7 @@ let make_cors_conf ~allowed_origin ~allowed_methods ~allowed_headers
       max_age;
       preflight;
       set_vary_header;
+      allow_no_origin;
     }
 
 let hdr_list_of_str hdr_str = String.split_on_char ',' hdr_str
@@ -157,7 +159,7 @@ let validate_origin conf req =
         | OriginUrlFn (_, url_fn) ->
             if orig = url_fn () then Ok true else Error OriginNotAllowed
         | _ -> Ok true)
-  | None -> Error MissingOrigin
+  | None -> if conf.allow_no_origin then Ok true else Error MissingOrigin
 
 let validate_request_method conf req =
   match Dream.header req "Access-Control-Request-Method" with
@@ -298,7 +300,7 @@ let handle_cors is_preflight conf inner_handler req =
     Dream.add_header rep "Access-Control-Expose-Headers"
     @@ hdr_str_of_list conf.expose_headers;
     if conf.set_vary_header then build_vary_header rep;
-    Utils.print_all_headers rep; (* Debug *)
+    Utils.print_all_headers rep;
     Lwt.return rep)
 
 let make_cors : cors_conf -> Dream.middleware = 

--- a/lib/cors/cors.mli
+++ b/lib/cors/cors.mli
@@ -41,7 +41,7 @@ type cors_error =
 val all_verbs_header : unit -> string list
 (** Helper function to make a header list of all http verbs. *)
 
-val non_preflight_headers : Dream.request -> (string * string) list
+val non_preflight_headers : Dream.response -> (string * string) list
 (** Helper function to return CORS relevant headers in non-preflight response.
 *)
 
@@ -53,6 +53,7 @@ val make_cors_conf :
   ?max_age:float ->
   ?preflight:bool ->
   ?set_vary_header:bool ->
+  ?allow_no_origin:bool ->
   unit ->
   cors_conf
 (** [make_cors_conf args...] makes a CORS configuration. *)

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -1,1 +1,9 @@
 let is_str_empty s = String.compare "" @@ String.trim s == 0
+
+let print_all_headers message =
+  let print_header (header: (string * string)) =
+    let t, c = header in
+    Dream.log "%s : %s" t c
+  in
+  Dream.log "%s" "--- Headers ---";
+  List.iter print_header (Dream.all_headers message)

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -3,7 +3,7 @@ let is_str_empty s = String.compare "" @@ String.trim s == 0
 let print_all_headers message =
   let print_header (header: (string * string)) =
     let t, c = header in
-    Dream.log "%s : %s" t c
+    Dream.debug (fun log -> log "%s : %s" t c)
   in
-  Dream.log "%s" "--- Headers ---";
+  Dream.debug (fun log -> log "%s" "--- Headers ---");
   List.iter print_header (Dream.all_headers message)

--- a/test/test_dream_middleware_ext.ml
+++ b/test/test_dream_middleware_ext.ml
@@ -514,7 +514,7 @@ let%expect_test "non_preflight_ok" =
   let open Cors in
   let cors_conf =
     make_cors_conf
-      ~allowed_origin:(OriginUrl (Allow, "http://127.0.0.1"))
+      ~allowed_origin:(OriginUrl (Disallow, "http://127.0.0.1"))
       ~allowed_methods:[ "GET"; "POST" ] ~allowed_headers:[ "A" ]
       ~expose_headers:[ "GET" ] ()
   in
@@ -536,7 +536,8 @@ let%expect_test "non_preflight_ok" =
     Response: 200 OK
     Access-Control-Allow-Origin: http://127.0.0.1
     Access-Control-Expose-Headers: GET
-    Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers |}]
+    Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
+    |}]
 
 let%expect_test "non_preflight_missing_origin" =
   let open Cors in

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -36,7 +36,6 @@ let show_cors ?(prefix = "/") ?(method_ = `GET) ?(headers = [ ("", "") ]) target
 
 let show_cors_non_preflight ?(prefix = "/") ?(method_ = `GET)
     ?(headers = [ ("", "") ]) target router =
-  let open Dream_middleware_ext.Cors in
   try
     let req = Dream.request ~method_ ~target ~headers "" in
     let response = Dream.test ~prefix router req in
@@ -46,13 +45,9 @@ let show_cors_non_preflight ?(prefix = "/") ?(method_ = `GET)
     in
     let status = Dream.status response in
     let headers = Dream.all_headers response in
-    let non_preflight_headers = non_preflight_headers req in
     Printf.printf "Response: %i %s\n"
       (Dream.status_to_int status)
       (Dream.status_to_string status);
     List.iter (fun (hrd, v) -> Printf.printf "%s: %s\n" hrd v) headers;
-    List.iter
-      (fun (hrd, v) -> Printf.printf "%s: %s\n" hrd v)
-      non_preflight_headers;
     if body <> "" then Printf.printf "%s\n" body else ()
   with Failure message -> print_endline message


### PR DESCRIPTION
## Motivation
Used your library to circumvent CORS when toying with an html file on disk. Opaque origin was not handled properly from what I understood (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin).
Also headers were added to the request, not the response.

## Solution
- Add pattern matching case to handle case where Origin is 'null'
- Fix headers being added to requests instead of responses
- Add a print_all_headers to display all headers in Dream's logger